### PR TITLE
feat: play Soundcloud tracks

### DIFF
--- a/config/settings.json.example
+++ b/config/settings.json.example
@@ -1,5 +1,6 @@
 {
-  "discord_token": "YOUR_DISCORD_TOKEN_HERE",
-  "channel_id": "VOICE_CHANNEL_ID",
+  "discord_token": "",
+  "soundcloud_client_id": "",
+  "channel_id": "",
   "shuffle": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-music-24-7",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -80,6 +80,14 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+      "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@discordjs/collection": {
@@ -242,6 +250,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -679,6 +695,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "fs-extra": {
       "version": "9.0.1",
@@ -1269,6 +1308,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -1405,6 +1449,16 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
+      }
+    },
+    "soundcloud-downloader": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/soundcloud-downloader/-/soundcloud-downloader-0.0.9.tgz",
+      "integrity": "sha512-46AbflAJPUngXcpv9n0/ISr0ZE0z1iLiVN3b2QDtEKXGyvWeERJeh9L6/78FS1TF8sVgNOeaozkcspd4C2brQQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "axios": "^0.19.2",
+        "m3u8stream": "^0.7.1"
       }
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@greencoast/logger": "^1.0.1",
     "discord.js": "^12.2.0",
     "fs-extra": "^9.0.1",
+    "soundcloud-downloader": "0.0.9",
     "ytdl-core": "^2.1.7"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -5,7 +5,7 @@ const appHandlers = require('./events/handlers/app');
 const Player = require('./classes/Player');
 
 const client = new Client();
-const player = new Player(client);
+const player = new Player(client, process.env.SOUNDCLOUD_CLIENT_ID);
 
 client.on(appEvents.error, appHandlers.handleError);
 client.on(appEvents.guildCreate, (guild) => appHandlers.handleGuildCreate(client, guild));

--- a/src/app.js
+++ b/src/app.js
@@ -1,11 +1,11 @@
 const { Client } = require('discord.js');
-const { discord_token } = require('../config/settings');
+const { discord_token, soundcloud_client_id } = require('../config/settings');
 const appEvents = require('./events/app');
 const appHandlers = require('./events/handlers/app');
 const Player = require('./classes/Player');
 
 const client = new Client();
-const player = new Player(client, process.env.SOUNDCLOUD_CLIENT_ID);
+const player = new Player(client, soundcloud_client_id);
 
 client.on(appEvents.error, appHandlers.handleError);
 client.on(appEvents.guildCreate, (guild) => appHandlers.handleGuildCreate(client, guild));

--- a/src/app.js
+++ b/src/app.js
@@ -1,11 +1,11 @@
 const { Client } = require('discord.js');
-const { discord_token, soundcloud_client_id } = require('../config/settings');
+const { discord_token } = require('../config/settings');
 const appEvents = require('./events/app');
 const appHandlers = require('./events/handlers/app');
 const Player = require('./classes/Player');
 
 const client = new Client();
-const player = new Player(client, soundcloud_client_id);
+const player = new Player(client);
 
 client.on(appEvents.error, appHandlers.handleError);
 client.on(appEvents.guildCreate, (guild) => appHandlers.handleGuildCreate(client, guild));

--- a/src/classes/Player.js
+++ b/src/classes/Player.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 const ytdl = require('ytdl-core');
 const scdl = require('soundcloud-downloader')
 const logger = require('@greencoast/logger');
-const { channel_id, shuffle } = require('../../config/settings');
+const { channel_id, shuffle, soundcloud_client_id } = require('../../config/settings');
 const { PRESENCE_STATUS, ACTIVITY_TYPE } = require('../constants');
 const { shuffleArray } = require('../utils');
 const streamEvents = require('../events/stream');
@@ -16,7 +16,7 @@ if (shuffle) {
 }
 
 class Player {
-  constructor(client, soundcloudClientID) {
+  constructor(client) {
     this.client = client;
     this.channel = null;
     this.connection = null;
@@ -25,7 +25,7 @@ class Player {
     this.songEntry = 0;
     this.paused = null;
     this.song = null;
-    this.soundcloudClientID = soundcloudClientID
+    this.soundcloudClientID = soundcloud_client_id
   }
 
   initialize() {
@@ -96,27 +96,8 @@ class Player {
     }
 
     try {
-      let stream;
-      const url = queue[this.songEntry]
-      if (queue[this.songEntry].includes('youtube.com')) {
-        stream = ytdl(queue[this.songEntry], {
-          quality: 'highestaudio',
-          highWaterMark: 1 << 25
-        });
-      } else if (queue[this.songEntry].includes('soundcloud.com') && this.soundcloudClientID !== undefined) {
-        stream = await scdl.download(queue[this.songEntry], this.soundcloudClientID)
-      }
+      const stream = await this.createStream()
       this.dispatcher = await this.connection.play(stream);
-
-      const info = await scdl.getInfo(url, this.soundcloudClientID)
-      this.song = info.title
-      stream.once(streamEvents.info, ({ title }) => {
-        if (!title) return
-        this.song = title;
-        if (!this.updateDispatcherStatus()) {
-          this.updateSongPresence();
-        }
-      });
 
       this.dispatcher.on(dispatcherEvents.speaking, (speaking) => {
         if (!speaking && !this.paused) {
@@ -141,6 +122,42 @@ class Player {
       this.songEntry++;
       this.play();
     }
+  }
+
+  async createStream() {
+    const url = queue[this.songEntry];
+    if (url.includes('youtube.com')) {
+      const stream = this.createYoutubeStream()
+      this.song = info.title;
+
+      stream.once(streamEvents.info, ({ title }) => {
+        this.song = title;
+        if (!this.updateDispatcherStatus()) {
+          this.updateSongPresence();
+        }
+      });
+
+    } else if (url.includes('soundcloud.com') && !!this.soundcloudClientID) {
+      const stream = await this.createSoundcloudStream();
+      const info = await scdl.getInfo(url, this.soundcloudClientID);
+
+      this.song = info.title;
+      if (!this.updateDispatcherStatus()) {
+        this.updateSongPresence();
+      }
+      return stream
+    }
+  }
+
+  createYoutubeStream() {
+    ytdl(queue[this.songEntry], {
+      quality: 'highestaudio',
+      highWaterMark: 1 << 25
+    });
+  }
+
+  async createSoundcloudStream() {
+    return await scdl.download(queue[this.songEntry], this.soundcloudClientID);
   }
 
   updateDispatcherStatus() {

--- a/src/classes/Player.js
+++ b/src/classes/Player.js
@@ -127,37 +127,39 @@ class Player {
   async createStream() {
     const url = queue[this.songEntry];
     if (url.includes('youtube.com')) {
-      const stream = this.createYoutubeStream()
-      this.song = info.title;
-
-      stream.once(streamEvents.info, ({ title }) => {
-        this.song = title;
-        if (!this.updateDispatcherStatus()) {
-          this.updateSongPresence();
-        }
-      });
+      return this.createYoutubeStream()
 
     } else if (url.includes('soundcloud.com') && !!this.soundcloudClientID) {
-      const stream = await this.createSoundcloudStream();
-      const info = await scdl.getInfo(url, this.soundcloudClientID);
-
-      this.song = info.title;
-      if (!this.updateDispatcherStatus()) {
-        this.updateSongPresence();
-      }
-      return stream
+      return await this.createSoundcloudStream();
     }
   }
 
   createYoutubeStream() {
-    ytdl(queue[this.songEntry], {
+    const stream = ytdl(queue[this.songEntry], {
       quality: 'highestaudio',
       highWaterMark: 1 << 25
     });
+
+    stream.once(streamEvents.info, ({ title }) => {
+      this.song = title;
+      if (!this.updateDispatcherStatus()) {
+        this.updateSongPresence();
+      }
+    });
+
+    return stream
   }
 
   async createSoundcloudStream() {
-    return await scdl.download(queue[this.songEntry], this.soundcloudClientID);
+    const stream = await scdl.download(queue[this.songEntry], this.soundcloudClientID);
+    const info = await scdl.getInfo(url, this.soundcloudClientID);
+
+    this.song = info.title;
+    if (!this.updateDispatcherStatus()) {
+      this.updateSongPresence();
+    }
+
+    return stream
   }
 
   updateDispatcherStatus() {

--- a/src/classes/Player.js
+++ b/src/classes/Player.js
@@ -152,7 +152,7 @@ class Player {
 
   async createSoundcloudStream() {
     const stream = await scdl.download(queue[this.songEntry], this.soundcloudClientID);
-    const info = await scdl.getInfo(url, this.soundcloudClientID);
+    const info = await scdl.getInfo(queue[this.songEntry], this.soundcloudClientID);
 
     this.song = info.title;
     if (!this.updateDispatcherStatus()) {
@@ -163,6 +163,10 @@ class Player {
   }
 
   updateDispatcherStatus() {
+    if (!this.dispatcher) {
+      return null;
+    }
+    
     if (this.listeners > 0) {
       return this.resumeDispatcher();
     }


### PR DESCRIPTION
The bot checks if the next URL in queue.txt is a YouTube or Soundcloud link and plays it using the appropriate interface. This requires the Player to be initialized with a Soundcloud Client ID which is configured in config.json. Info on obtaining a Client ID can be found [here](https://github.com/zackradisic/node-soundcloud-downloader#client-id).