### PR TITLE
Version 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ The bot can play music from the following URLs:
 
 Playlists are not officially supported yet. You may find that they may work but generally only the first song will be pulled from them.
 
+You can also play radio streams, as long as the stream is of the following types:
+
+* `audio/aac`
+* `audio/mpeg`
+* `audio/ogg`
+* `audio/opus`
+* `audio/wav`
+
+> Pausing/Resuming may take a bit longer with these streams.
+
 ## Getting 429 Too Many Requests (YouTube)
 
 If you're reaching **429: Too Many Requests** errors in the console, then most likely you're being rate limited by YouTube because your connection is not authenticated.

--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,0 +1,5 @@
+module.exports = {
+  default: {
+    get: jest.fn()
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-music-24-7",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-music-24-7",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A 24/7 music bot for Discord.",
   "main": "./src/app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@discordjs/opus": "^0.5.3",
     "@greencoast/discord.js-extended": "^1.2.0",
     "@greencoast/logger": "^1.1.0",
+    "axios": "^0.21.1",
     "discord.js": "^12.5.3",
     "music-metadata": "^7.11.3",
     "soundcloud-downloader": "^1.0.0",

--- a/src/classes/providers/GenericStreamProvider.js
+++ b/src/classes/providers/GenericStreamProvider.js
@@ -1,0 +1,48 @@
+const AbstractProvider = require('./AbstractProvider');
+const URLError = require('../errors/URLError');
+const axios = require('axios').default;
+const logger = require('@greencoast/logger');
+
+class GenericStreamProvider extends AbstractProvider {
+  async createStream(source) {
+    try {
+      const response = await axios.get(source, {
+        responseType: 'stream'
+      });
+      const info = await this.getInfo(source);
+
+      const contentType = response.headers['content-type'];
+      if (!GenericStreamProvider.isStreamSupported(contentType)) {
+        throw new URLError(`${source} resolves to an unsupported stream of type ${contentType}.`);
+      }
+
+      response.data.info = {
+        title: info,
+        source: 'GENERIC'
+      };
+
+      return response.data;
+    } catch (error) {
+      logger.error(error);
+      return null;
+    }
+  }
+
+  getInfo(source) {
+    return Promise.resolve(source);
+  }
+}
+
+GenericStreamProvider.MIME_TYPES = [
+  'audio/aac',
+  'audio/mpeg',
+  'audio/ogg',
+  'audio/opus',
+  'audio/wav'
+];
+
+GenericStreamProvider.isStreamSupported = (mimeType) => {
+  return GenericStreamProvider.MIME_TYPES.includes(mimeType);
+};
+
+module.exports = GenericStreamProvider;

--- a/src/classes/providers/ProviderFactory.js
+++ b/src/classes/providers/ProviderFactory.js
@@ -1,13 +1,14 @@
 const YouTubeProvider = require('../providers/YouTubeProvider');
 const SoundCloudProvider = require('../providers/SoundCloudProvider');
 const LocalProvider = require('../providers/LocalProvider');
-const URLError = require('../errors/URLError');
+const GenericStreamProvider = require('../providers/GenericStreamProvider');
 
 class ProviderFactory {
   constructor(options = {}) {
     this._youtubeProvider = new YouTubeProvider(options.youtubeCookie);
     this._soundCloudProvider = new SoundCloudProvider(options.soundcloudClientID);
     this._localProvider = new LocalProvider();
+    this._genericStreamProvider = new GenericStreamProvider();
   }
 
   getInstance(url) {
@@ -23,7 +24,7 @@ class ProviderFactory {
       return this._localProvider;
     }
     
-    throw new URLError(`Invalid URL in queue: ${url}`);
+    return this._genericStreamProvider;
   }
 }
 

--- a/test/classes/providers/GenericStreamProvider.spec.js
+++ b/test/classes/providers/GenericStreamProvider.spec.js
@@ -1,0 +1,87 @@
+const GenericStreamProvider = require('../../../src/classes/providers/GenericStreamProvider');
+const AbstractProvider = require('../../../src/classes/providers/AbstractProvider');
+const logger = require('@greencoast/logger');
+const axios = require('axios').default;
+const { Readable } = require('stream');
+
+jest.mock('@greencoast/logger');
+jest.mock('axios');
+
+const STREAM_URL = 'http://stream.laut.fm/foxco-radio';
+
+describe('Classes - Providers - GenericStreamProvider', () => {
+  let provider;
+
+  beforeEach(() => {
+    provider = new GenericStreamProvider();
+
+    logger.error.mockClear();
+    axios.get.mockClear();
+  });
+
+  it('should be instance of AbstractProvider.', () => {
+    expect(provider).toBeInstanceOf(AbstractProvider);
+  });
+
+  describe('createStream()', () => {
+    beforeEach(() => {
+      axios.get.mockReturnValue({
+        data: new Readable(),
+        headers: {
+          ['content-type']: 'audio/mpeg'
+        }
+      });
+    });
+
+    it('should return a Promise.', () => {
+      expect(provider.createStream(STREAM_URL)).toBeInstanceOf(Promise);
+    });
+
+    it('should resolve a stream.', () => {
+      return provider.createStream(STREAM_URL)
+        .then((stream) => {
+          expect(stream).toBeInstanceOf(Readable);
+        });
+    });
+
+    it('should resolve a stream with the proper info property.', () => {
+      return provider.createStream(STREAM_URL)
+        .then((stream) => {
+          expect(stream).toHaveProperty('info');
+          expect(stream.info.title).toBe(STREAM_URL);
+          expect(stream.info.source).toBe('GENERIC');
+        });
+    });
+
+    it('should log an error if stream is not valid.', () => {
+      axios.get.mockReturnValueOnce({
+        headers: {
+          ['content-type']: 'video/mp4'
+        }
+      });
+
+      return provider.createStream(STREAM_URL)
+        .then(() => {
+          expect(logger.error).toHaveBeenCalled();
+        });
+    });
+  });
+
+  describe('getInfo()', () => {
+    it('should return a Promise.', () => {
+      expect(provider.getInfo(STREAM_URL)).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe('static isStreamSupported()', () => {
+    it('should return true if content-type is supported.', () => {
+      GenericStreamProvider.MIME_TYPES.forEach((type) => {
+        expect(GenericStreamProvider.isStreamSupported(type)).toBe(true);
+      });
+    });
+
+    it('should return false if content-type is unsupported.', () => {
+      expect(GenericStreamProvider.isStreamSupported('video/mp4')).toBe(false);
+    });
+  });
+});

--- a/test/classes/providers/ProviderFactory.spec.js
+++ b/test/classes/providers/ProviderFactory.spec.js
@@ -1,8 +1,8 @@
 const ProviderFactory = require('../../../src/classes/providers/ProviderFactory');
-const URLError = require('../../../src/classes/errors/URLError');
 const YouTubeProvider = require('../../../src/classes/providers/YouTubeProvider');
 const SoundCloudProvider = require('../../../src/classes/providers/SoundCloudProvider');
 const LocalProvider = require('../../../src/classes/providers/LocalProvider');
+const GenericStreamProvider = require('../../../src/classes/providers/GenericStreamProvider');
 
 describe('Classes - Providers - ProviderFactory', () => {
   let factory;
@@ -12,12 +12,6 @@ describe('Classes - Providers - ProviderFactory', () => {
   });
 
   describe('getInstance()', () => {
-    it('should throw URLError if url is not supported.', () => {
-      expect(() => {
-        factory.getInstance('https://notsupported.tld');
-      }).toThrow(URLError);
-    });
-
     it('should return a YouTubeProvider if url corresponds to YouTube.', () => {
       expect(factory.getInstance('https://www.youtube.com/watch?v=PYGODWJgR-c')).toBeInstanceOf(YouTubeProvider);
       expect(factory.getInstance('https://youtu.be/PYGODWJgR-c')).toBeInstanceOf(YouTubeProvider);
@@ -29,6 +23,10 @@ describe('Classes - Providers - ProviderFactory', () => {
 
     it('should return a LocalProvider if url corresponds to a local file.', () => {
       expect(factory.getInstance('local:/path/to/audio/file')).toBeInstanceOf(LocalProvider);
+    });
+
+    it('should return a GenericStreamProvider if url does not correspond to any of the above.', () => {
+      expect(factory.getInstance('https://generic.stream.tld')).toBeInstanceOf(GenericStreamProvider);
     });
   });
 });


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.

### :page_facing_up: Description

This PR adds support for generic streams. You can add a URL to the queue that resolves to a radio stream. If the URL is not normally supported by any other provider, it will be taken as a generic one and the bot will try to get the stream.

### :pushpin: Does this PR address any issue?

#37
